### PR TITLE
16 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-root.build/ignore-errors = otrs2
-
 COMMON_OVERLAYS = tkl-webcp apache
 COMMON_CONF = apache-vhost apache-credit tkl-webcp
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,12 @@
+turnkey-otrs-16.0 (1) turnkey; urgency=low
+
+  * Include latest OTRS Debian package update
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Stefan Davis <stefan@turnkeylinux.org>  Tue, 17 Mar 2020 14:39:01 +1100
+
 turnkey-otrs-15.1 (1) turnkey; urgency=low
 
   * Include latest OTRS Debian package update - closes #1238.

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,50 +1,49 @@
 #!/bin/sh -ex
 
-# turnkey hash: crypt.crypt('turnkey', 'ro')
-ADMIN_PASS=ro6EFA5u.JX06
-DB_NAME=otrs2
-DB_USER=otrs2
+ADMIN_PASS=turnkey
+DB_NAME=otrs
+DB_USER=otrs
 
 # start mysql
 service mysql start
 
-# ugly workaround: preseeding debconf doesn't work
-cat > /etc/dbconfig-common/otrs2.conf << EOF
-dbc_install='true'
-dbc_upgrade='true'
-dbc_remove=''
-dbc_dbtype='mysql'
-dbc_dbuser='otrs2'
-dbc_dbpass='turnkey'
-dbc_dbserver=''
-dbc_dbport=''
-dbc_dbname='otrs2'
-dbc_dbadmin='root'
-dbc_basepath=''
-dbc_ssl=''
-dbc_authmethod_admin=''
-dbc_authmethod_user=''
-EOF
-dbconfig-generate-include -f perl /etc/dbconfig-common/otrs2.conf /etc/otrs/database.pm
-
-# setup the database
 MYSQL_BATCH="mysql --user=root --password=$MYSQL_PASS --batch"
 MYSQL_ADMIN="mysqladmin --user=root --password=$MYSQL_PASS"
 
-$MYSQL_ADMIN create otrs2 --default-character-set=utf8;
-patch /usr/share/dbconfig-common/data/otrs2/install/mysql /usr/local/src/otrs-db-install.patch
-mysql otrs2 < /usr/share/dbconfig-common/data/otrs2/install/mysql
-$MYSQL_BATCH --execute "grant all privileges on $DB_NAME.* to $DB_USER@localhost identified by 'turnkey'; flush privileges;"
+$MYSQL_ADMIN create otrs --default-character-set=utf8;
 
-# this configures otrs (incomplete install in root.buid)
-DEBIAN_FRONTEND=noninteractive apt-get -y -f install otrs2
-
-# set admin username and password
-mysql --defaults-extra-file=/etc/mysql/debian.cnf <<EOF
-USE otrs2;
-UPDATE users SET login = 'admin', pw = '$ADMIN_PASS'
-WHERE id = 1;
+cat <<EOF | debconf-set-selections
+otrs2   otrs2/app-password-confirm  password turnkey
+otrs2   otrs2/password-confirm  password turnkey
+otrs2   otrs2/mysql/admin-pass  password
+otrs2   otrs2/mysql/admin-user  string  root
+otrs2   otrs2/dbconfig-install  boolean true
+otrs2   otrs2/internal/reconfiguring    boolean false
+otrs2   otrs2/install-error select  abort
+otrs2   otrs2/database-type select  mysql
+otrs2   otrs2/mysql/method  select  Unix socket
+otrs2   otrs2/internal/skip-preseed boolean false
+otrs2   otrs2/db/dbname string  $DB_NAME
+otrs2   otrs2/upgrade-backup    boolean true
+otrs2   otrs2/upgrade-error select  abort
+otrs2   otrs2/dbconfig-reinstall    boolean false
+otrs2   otrs2/db/app-user   string  $DB_NAME@localhost
+otrs2   otrs2/dbconfig-remove   boolean true
+otrs2   otrs2/passwords-do-not-match    error   
+otrs2   otrs2/missing-db-package-error  select  abort
+otrs2   otrs2/remote/port   string  
+otrs2   otrs2/remote/host   select  localhost
+otrs2   otrs2/purge boolean false
+otrs2   otrs2/dbconfig-upgrade  boolean true
+otrs2   otrs2/remote/newhost    string  
+otrs2   otrs2/remove-error  select  abort
 EOF
+
+apt update
+DEBIAN_FRONTEND=noninteractive apt install --assume-yes otrs2
+
+# set admin password
+su -c '/usr/share/otrs/bin/otrs.Console.pl Admin::User::SetPassword root@localhost '"$ADMIN_PASS" -s /bin/bash otrs
 
 # configure permissions
 /usr/share/otrs/bin/otrs.SetPermissions.pl \
@@ -66,9 +65,12 @@ a2dissite 000-default
 a2ensite otrs2
 a2enmod cgid
 
+
+# cron email config
+sed 's/^#MAILTO=\(.*\)$/MAILTO=\1/' /etc/otrs/cron
+
 mkdir /run/otrs
 chown otrs:nogroup /run/otrs
-
 cd /usr/share/otrs/
 cp ./var/cron/otrs_daemon.dist ./var/cron/otrs_daemon
 su -c './bin/Cron.sh start' -s /bin/bash otrs

--- a/overlay/etc/mysql/mariadb.conf.d/70-barracuda.cnf
+++ b/overlay/etc/mysql/mariadb.conf.d/70-barracuda.cnf
@@ -1,5 +1,0 @@
-[mysqld]
-innodb_file_per_table=1
-innodb_file_format = Barracuda
-innodb_file_format_max = Barracuda
-innodb_large_prefix=1

--- a/overlay/usr/lib/inithooks/bin/otrs.py
+++ b/overlay/usr/lib/inithooks/bin/otrs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """Set OTRS admin password
 
 Option:
@@ -8,25 +8,28 @@ Option:
 
 import sys
 import getopt
-import crypt
+import shlex
+import inithooks_cache
+import re
 
 from dialog_wrapper import Dialog
-from mysqlconf import MySQL
+import subprocess
 
 def usage(s=None):
     if s:
-        print >> sys.stderr, "Error:", s
-    print >> sys.stderr, "Syntax: %s [options]" % sys.argv[0]
-    print >> sys.stderr, __doc__
+        print("Error:", s, file=sys.stderr)
+    print("Syntax: %s [options]" % sys.argv[0], file=sys.stderr)
+    print(__doc__, file=sys.stderr)
     sys.exit(1)
 
 def main():
     try:
-        opts, args = getopt.gnu_getopt(sys.argv[1:], "h", ['help', 'pass='])
-    except getopt.GetoptError, e:
+        opts, args = getopt.gnu_getopt(sys.argv[1:], "h", ['help', 'pass=', 'email='])
+    except getopt.GetoptError as e:
         usage(e)
 
     password = ""
+    email = ""
     for opt, val in opts:
         if opt in ('-h', '--help'):
             usage()
@@ -39,10 +42,31 @@ def main():
             "OTRS Password",
             "Enter new password for the OTRS 'admin' account.")
 
-    hashpass = crypt.crypt(password, 'ro')
+    if not email:
+        if 'd' not in locals():
+            d = Dialog('Turnkey Linux - First boot configuration')
+        
+        email = d.get_email(
+            "OTRS Email",
+            "Enter email address for the OTRS 'admin' account.",
+            "admin@example.com")
 
-    m = MySQL()
-    m.execute('UPDATE otrs2.users SET pw=\"%s\" WHERE login=\"admin\";' % hashpass)
+    inithooks_cache.write('APP_EMAIL', email)
+
+    quoted_password = shlex.quote(password)
+    subprocess.run(['su', '-c',
+        f'/usr/share/otrs/bin/otrs.Console.pl Admin::User::SetPassword root@localhost {quoted_password}',
+        '-s', '/bin/bash', 'otrs'])
+    
+    lines = []
+    with open('/etc/otrs/cron', 'r') as fob:
+        for line in fob:
+            lines.append(re.sub(
+                r'^MAILTO=".*"\s*$',
+                'MAILTO={}'.format(shlex.quote(email)),
+                line))
+    with open('/etc/otrs/cron', 'w') as fob:
+        fob.writelines(lines)
 
 if __name__ == "__main__":
     main()

--- a/overlay/usr/lib/inithooks/firstboot.d/20regen-otrs-secrets
+++ b/overlay/usr/lib/inithooks/firstboot.d/20regen-otrs-secrets
@@ -9,6 +9,6 @@ CONF=/etc/dbconfig-common/otrs2.conf
 sed -i "s/dbc_dbpass=\(.*\)/dbc_dbpass=\'$PASSWORD\'/" $CONF
 dbconfig-generate-include -f perl /etc/dbconfig-common/otrs2.conf /etc/otrs/database.pm
 
-$INITHOOKS_PATH/bin/mysqlconf.py --user=otrs2 --pass="$PASSWORD"
+$INITHOOKS_PATH/bin/mysqlconf.py --user=otrs --pass="$PASSWORD"
 
 service apache2 restart

--- a/plan/main
+++ b/plan/main
@@ -1,6 +1,12 @@
 #include <turnkey/base>
+#include <turnkey/mysql>
 
-otrs2
+//otrs2
+//   requires libmailtools-perl
+//   which requires libnet-perl which is a virtual package
+//   provided by perl-modules which is a virtual package
+//   provided by perl-modules-5.28
+apache2
 
 ispell
 wamerican-large
@@ -12,7 +18,7 @@ libcgi-pm-perl
 
 libmodule-refresh-perl /* OTRS deps */
 libclass-inspector-perl
-libsoap-lite-perl
+//libsoap-lite-perl requires libmailtools-perl
 
 libtext-csv-xs-perl /* optional - but recommended */
 libjson-xs-perl /* optional - but recommended */
@@ -28,6 +34,5 @@ libapache2-mod-perl2
 libapache2-reload-perl
 webmin-apache
 
-mysql-server
 libdbd-mysql-perl
 webmin-mysql


### PR DESCRIPTION
- Update otrs to the latest debian packaged version.
- Changed db name & user from "otrs" to "otrs2" both for future proofing and because the current otrs package expects a db by this name by default.